### PR TITLE
Making label background color explicit.  Changed label text color to …

### DIFF
--- a/Basics/networking.playground/Contents.swift
+++ b/Basics/networking.playground/Contents.swift
@@ -20,7 +20,8 @@ guard let url = components.url else {
 // -- Creating a label to display our result in --
 
 let label = UILabel()
-label.textColor = .white
+label.textColor = .darkGray
+label.backgroundColor = .white
 label.numberOfLines = 0
 label.frame.size = CGSize(width: 300, height: 300)
 PlaygroundPage.current.liveView = label

--- a/Basics/networking.playground/contents.xcplayground
+++ b/Basics/networking.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' executeOnSourceChanges='false'>
+<playground version='5.0' target-platform='ios'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>


### PR DESCRIPTION
Hi - I have been learning to code with Swift and have enjoyed your playground examples that are attached to the Basic articles.  Thanks!

For the Networking sandbox I couldn't figure out why the data was not loading from the API.  Then I realized the data was loading but it was white text on a white label.  I suspect the default label background color changed in Xcode?  Anyway, I tweaked it to make the background and text both an explicit color.  And thought I would take the opportunity to figure out how to do a pull request.